### PR TITLE
ERC-8040: compliance, links relativos e padrão EIP-1

### DIFF
--- a/ERCS/erc-8040.md
+++ b/ERCS/erc-8040.md
@@ -13,7 +13,7 @@ requires: 20, 721, 1155
 
 # Abstract
 
-This ERC defines a compliance-grade, AI-native protocol for ESG-compliant asset tokenization, governed by ATF-AI and protected by post-quantum cryptography. It codifies lifecycle, metadata, and auditability for compliance-grade deployment, aligns with UN SDGs, and enforces machine-verifiable governance for public, audit-ready markets.
+This EIP defines a compliance-grade, AI-native protocol for ESG-compliant asset tokenization, governed by ATF-AI and protected by post-quantum cryptography. It codifies lifecycle, metadata, and auditability for compliance-grade deployment, aligns with UN SDGs, and enforces machine-verifiable governance for public, audit-ready markets.
 
 # Motivation
 

--- a/ERCS/erc-8040.md
+++ b/ERCS/erc-8040.md
@@ -13,7 +13,7 @@ requires: 20, 721, 1155
 
 # Abstract
 
-This EIP defines a compliance-grade, AI-native protocol for ESG-compliant asset tokenization, governed by ATF-AI and protected by post-quantum cryptography. It codifies lifecycle, metadata, and auditability for compliance-grade deployment, aligns with UN SDGs, and enforces machine-verifiable governance for public, audit-ready markets.
+This ERC defines a compliance-grade, AI-native protocol for ESG-compliant asset tokenization, governed by ATF-AI and protected by post-quantum cryptography. It codifies lifecycle, metadata, and auditability for compliance-grade deployment, aligns with UN SDGs, and enforces machine-verifiable governance for public, audit-ready markets.
 
 # Motivation
 
@@ -154,7 +154,7 @@ Governance is executed through an AI-Governed DAO rather than discretionary huma
 
 # Backwards Compatibility
 
-This standard does not break ERC-20/721/1155 compatibility.
+This standard does not break [**ERC-20**](https://eips.ethereum.org/EIPS/eip-20), [**ERC-721**](https://eips.ethereum.org/EIPS/eip-721), and [**ERC-1155**](https://eips.ethereum.org/EIPS/eip-1155) compatibility.
 
 - Legacy tokens may reference metadata externally but lack full ATF-AI compliance
 - Migration tools can wrap legacy tokens with compliant metadata
@@ -185,7 +185,7 @@ This standard does not break ERC-20/721/1155 compatibility.
 
 - **Repository**: [agrocrypto-core](https://github.com/AgroCryptoLabs/agrocrypto-core)
 - **Version**: v2.0.0
-- **Authors**: AgroCrypto Labs LLC
+- **Authors**: Leandro Lemos
 - **License**: CC0-1.0
 
 ### Reference Hashes (for auditability)
@@ -200,8 +200,6 @@ f81783bcda0f70958b05732651fb7ca30a0cef4c3acf0bf45ca4dfa3e7a23645
 # Copyright
 
 Copyright and related rights waived via CC0-1.0.
-
-© 2023–2025 AgroCrypto Labs LLC — compliance-grade framework.
 
 # Changelog
 
@@ -225,8 +223,6 @@ All changes to this protocol are treated as compliance-grade events. Each entry 
 f81783bcda0f70958b05732651fb7ca30a0cef4c3acf0bf45ca4dfa3e7a23645
 ```
 
-## [1.0.1] — Planned
-
 **Planned Features**
 - Integration with AgroPay for ESG token lifecycle tracking
 - Visual seal registry with cryptographic linkage to metadata
@@ -234,15 +230,4 @@ f81783bcda0f70958b05732651fb7ca30a0cef4c3acf0bf45ca4dfa3e7a23645
 - Optional bridge module for multi-chain deployment
 - Enhanced JSON-RPC documentation
 
-# Compliance Notes
 
-- All corrections are treated as compliance-grade events
-- Hashes are published publicly and timestamped
-- No retroactive edits permitted without changelog entry
-- All amendments require consensus from ATF-AI governance
-
----
-
-**© 2023–2025 AgroCrypto Labs LLC — compliance-grade framework**
-
----

--- a/ERCS/erc-8040.md
+++ b/ERCS/erc-8040.md
@@ -183,7 +183,7 @@ This standard does not break [**ERC-20**](https://eips.ethereum.org/EIPS/eip-20)
 
 # Reference Implementation
 
-- **Repository**: [agrocrypto-core](https://github.com/AgroCryptoLabs/agrocrypto-core)
+- **Repository**: [agrocrypto-core](https://github.com/agronetlabs/agrocrypto-core)
 - **Version**: v2.0.0
 - **Authors**: Leandro Lemos
 - **License**: CC0-1.0

--- a/ERCS/erc-8040.md
+++ b/ERCS/erc-8040.md
@@ -1,8 +1,8 @@
 ---
-erc: 8040
+eip: 8040
 title: ESG Tokenization Protocol
 description: AI-native ESG asset tokenization with lifecycle integrity, attestations, audit trail, and PQC readiness.
-author: Leandro Lemos (@agronetlabs) <leandro@agronet.io>
+author: Leandro Lemos <leandro@agronet.io>
 discussions-to: https://ethereum-magicians.org/t/erc-8040-esg-tokenization-protocol/25846
 status: Draft
 type: Standards Track
@@ -127,9 +127,9 @@ event Retired(uint256 indexed tokenId, uint256 timestamp, string reason);
 
 ## Mapping & Compatibility
 
-- **ERC-20**: Each unit represents a standardized fraction (e.g., 1e18 = 1 tCO2e).
-- **ERC-721**: Single credit with unique esgURI and immutable metadata.
-- **ERC-1155**: Homogeneous batch with common URI, metadata, and fungible amounts.
+- [**ERC-20**](./eip-20.md): Each unit represents a standardized fraction (e.g., 1e18 = 1 tCO2e).
+- [**ERC-721**](./eip-721.md): Single credit with unique esgURI and immutable metadata.
+- [**ERC-1155**](./eip-1155.md): Homogeneous batch with common URI, metadata, and fungible amounts.
 
 # Rationale
 
@@ -153,12 +153,7 @@ Governance is executed through an AI-Governed DAO rather than discretionary huma
 - Zero-trust validation ensures all attestations are timestamped and verifiable
 
 # Backwards Compatibility
-
-This standard does not break [**ERC-20**](https://eips.ethereum.org/EIPS/eip-20), [**ERC-721**](https://eips.ethereum.org/EIPS/eip-721), and [**ERC-1155**](https://eips.ethereum.org/EIPS/eip-1155) compatibility.
-
-- Legacy tokens may reference metadata externally but lack full ATF-AI compliance
-- Migration tools can wrap legacy tokens with compliant metadata
-- Gradual adoption is supported through optional interface implementation
+This standard does not break [**ERC-20**](./eip-20.md), [**ERC-721**](./eip-721.md), and [**ERC-1155**](./eip-1155.md) compatibility.
 
 # Test Cases
 
@@ -197,15 +192,9 @@ f81783bcda0f70958b05732651fb7ca30a0cef4c3acf0bf45ca4dfa3e7a23645
 
 **Timestamp**: 2025-09-06T08:21:00 PDT
 
-# Copyright
-
-Copyright and related rights waived via CC0-1.0.
-
 # Changelog
 
 All changes to this protocol are treated as compliance-grade events. Each entry is timestamped and hashed for public auditability.
-
-## [1.0.0] — 2025-09-06
 
 **Added**
 - Initial publication of ERC-8040 ESG Tokenization Protocol
@@ -231,3 +220,5 @@ f81783bcda0f70958b05732651fb7ca30a0cef4c3acf0bf45ca4dfa3e7a23645
 - Enhanced JSON-RPC documentation
 
 
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8040.md
+++ b/ERCS/erc-8040.md
@@ -153,7 +153,7 @@ Governance is executed through an AI-Governed DAO rather than discretionary huma
 - Zero-trust validation ensures all attestations are timestamped and verifiable
 
 # Backwards Compatibility
-This standard does not break [**ERC-20**](./eip-20.md), [**ERC-721**](./eip-721.md), and [**ERC-1155**](./eip-1155.md) compatibility.
+This standard does not break [**ERC-20**](./erc-20.md), [**ERC-721**](./erc-721.md), and [**ERC-1155**](./erc-1155.md) compatibility.
 
 # Test Cases
 

--- a/ERCS/erc-8040.md
+++ b/ERCS/erc-8040.md
@@ -1,15 +1,14 @@
 ---
-eip: 8040
+erc: 8040
 title: ESG Tokenization Protocol
-description: AI-native ESG asset tokenization protocol ensuring lifecycle integrity and quantum-grade auditability.
+description: AI-native ESG asset tokenization with lifecycle integrity, attestations, audit trail, and PQC readiness.
 author: Leandro Lemos (@agronetlabs) <leandro@agronet.io>
-discussions-to: https://ethereum-magicians.org/t/erc-8040-esg-tokenization-protocol/19840
+discussions-to: https://ethereum-magicians.org/t/erc-8040-esg-tokenization-protocol/25846
 status: Draft
 type: Standards Track
 category: ERC
 created: 2025-09-06
 requires: 20, 721, 1155
-license: CC0
 ---
 
 # Abstract

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Consider any document not published at <https://eips.ethereum.org/> as a working
 
 ## ERC-8040 — ESG Tokenization Protocol
 
-- Release: https://github.com/agronetlabs/ERCs/releases/tag/v1.0.0
+- Reference implementation release (external): https://github.com/agronetlabs/ERCs/releases/tag/v1.0.0
 - Discussion (Magicians): https://ethereum-magicians.org/t/erc-8040-esg-tokenization-protocol/25846
 - Spec file: ERCS/erc-8040.md

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ If you would like to become an EIP Editor, please read [EIP-5069](https://eips.e
 The canonical URL for an ERC that has achieved draft status at any point is at <https://eips.ethereum.org/>. For example, the canonical URL for EIP-1 is <https://eips.ethereum.org/EIPS/eip-1>.
 
 Consider any document not published at <https://eips.ethereum.org/> as a working paper. Additionally, consider published EIPs with a status of "draft", "review", or "last call" to be incomplete drafts, and note that their specification is likely to be subject to change.
+
+## ERC-8040 — ESG Tokenization Protocol
+
+- Release: https://github.com/agronetlabs/ERCs/releases/tag/v1.0.0
+- Discussion (Magicians): https://ethereum-magicians.org/t/erc-8040-esg-tokenization-protocol/25846
+- Spec file: ERCS/erc-8040.md


### PR DESCRIPTION
Corrige todos os links para formato relativo, conforme padrão EIP-1 e ERC-1154. Pronto para validação final do CI/Copilot.